### PR TITLE
Make wind retrieval example work with arts-2-3-1099

### DIFF
--- a/retrievals/wind_3d.ipynb
+++ b/retrievals/wind_3d.ipynb
@@ -580,8 +580,8 @@
     "ws.atmgeom_checkedCalc()\n",
     "ws.atmfields_checkedCalc()\n",
     "ws.abs_xsec_agenda_checkedCalc()\n",
-    "ws.cloudboxOff()\n",
     "ws.jacobianOff()\n",
+    "ws.cloudboxOff()\n",
     "ws.cloudbox_checkedCalc()"
    ]
   },
@@ -718,6 +718,7 @@
     "    ws.Print(ws.y)\n",
     "    ws.Print(ws.jacobian)\n",
     "    ws.VectorAddVector( ws.yf, ws.y, ws.y_baseline )\n",
+    "    ws.IndexAdd(ws.inversion_iteration_counter, ws.inversion_iteration_counter, 1)\n",
     "    \n",
     "ws.Copy(ws.inversion_iterate_agenda, inversion_iterate_agenda)"
    ]


### PR DESCRIPTION
Current example does not work anymore with arts-2-3-1099 (r11054, 2018-08-23). Some WSMs might have changed in the last few months.

Changes that made it work again:
* Call WSM cloudboxOff after jacobianOff
* Explicitly increment WSV inversion_iteration_counter in inversion agenda

Now the example works again.